### PR TITLE
adding header value if missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,88 +5,84 @@
  */
 
 var express = require('express'),
-  https = require('https'),
-  http = require('http'),
-  mod_url = require('url')
+      https = require('https'),
+       http = require('http'),
+    mod_url = require('url');
 
-var utils = require('./utils')
+var utils = require('./utils');
 
 module.exports = function(options, cb) {
-  var app = express()
+  var app = express();
 
   // parse credentials from Authorization header into req.remote_*
   app.use(function(req, res, next) {
-    var creds = utils.authorization(req.headers['authorization'])
+    var creds = utils.authorization(req.headers['authorization']);
 
-    if (!creds) return utils.unauthorized(res, options.realm)
+    if(!creds)
+      return utils.unauthorized(res, options.realm);
 
-    req.remote_user = creds[0]
-    req.remote_pass = creds[1]
+    req.remote_user = creds[0];
+    req.remote_pass = creds[1];
 
-    next()
-  })
+    next();
+  });
 
   // CouchDB replication base endpoint
   app.all('/:db/*', function(req, res) {
-    req.pause()
+    req.pause();
 
     cb(req.params.db, req.remote_user, req.remote_pass, function(err, url) {
-      if (err) return utils.unauthorized(res, options.realm, err.message)
+      if(err)
+        return utils.unauthorized(res, options.realm, err.message);
 
-      var remoteHeaders = {}
-      for (var header in req.headers) {
-        if (req.headers.hasOwnProperty(header)) {
-          remoteHeaders[header] = req.headers[header]
+      var remoteHeaders = {};
+      for(var header in req.headers) {
+        if(req.headers.hasOwnProperty(header)) {
+          remoteHeaders[header] = req.headers[header];
         }
       }
 
-      delete remoteHeaders['authorization']
-      delete remoteHeaders['host']
+      delete remoteHeaders['authorization'];
+      delete remoteHeaders['host'];
 
-      var remoteURL = mod_url.parse(url)
-      remoteURL.path += req.url.slice(req.params.db.length + 1)
+      var remoteURL = mod_url.parse(url);
+      remoteURL.path += req.url.slice(req.params.db.length + 1);
 
-      var request = 'https:' == remoteURL.protocol
-        ? https.request
-        : http.request
+      var request = 'https:' == remoteURL.protocol ? https.request : http.request;
 
-      var remoteReq = request(
-        {
-          method: req.method,
-          hostname: remoteURL.hostname,
-          port: remoteURL.port || ('https:' == remoteURL.protocol ? 443 : 80),
-          path: remoteURL.path,
-          headers: remoteHeaders,
-          auth: remoteURL.auth
-        },
-        function(remoteRes) {
-          // node's HTTP parser has already parsed any chunked encoding
-          delete remoteRes.headers['transfer-encoding']
+      var remoteReq = request({
+        method: req.method,
+        hostname: remoteURL.hostname,
+        port: remoteURL.port || ('https:' == remoteURL.protocol ? 443 : 80),
+        path: remoteURL.path,
+        headers: remoteHeaders,
+        auth: remoteURL.auth,
+      }, function(remoteRes) {
+        // node's HTTP parser has already parsed any chunked encoding
+        delete remoteRes.headers['transfer-encoding'];
 
-          remoteRes.headers['content-type']
-            ? null
-            : (remoteRes.headers['content-type'] = 'application/json')
-          // CouchDB replication fails unless we use a properly-cased header
-          remoteRes.headers['Content-Type'] = remoteRes.headers['content-type']
-          delete remoteRes.headers['content-type']
+        remoteRes.headers['content-type']
+      ? null
+      : (remoteRes.headers['content-type'] = 'application/json');
+        // CouchDB replication fails unless we use a properly-cased header
+        remoteRes.headers['Content-Type'] = remoteRes.headers['content-type'];
+        delete remoteRes.headers['content-type'];
 
-          res.writeHead(remoteRes.statusCode, remoteRes.headers)
-          remoteRes.pipe(res)
-        }
-      )
+
+
+        res.writeHead(remoteRes.statusCode, remoteRes.headers);
+        remoteRes.pipe(res);
+      });
 
       remoteReq.on('error', function(err) {
-        res.json(503, {
-          error: 'db_unavailable',
-          reason: err.syscall + ' ' + err.errno
-        })
-      })
+        res.json(503, {error: 'db_unavailable', reason: err.syscall + ' ' + err.errno});
+      });
 
-      req.setEncoding('utf8')
-      req.resume()
-      req.pipe(remoteReq)
-    })
-  })
+      req.setEncoding('utf8');
+      req.resume();
+      req.pipe(remoteReq);
+    });
+  });
 
-  return app
-}
+  return app;
+};

--- a/index.js
+++ b/index.js
@@ -5,79 +5,88 @@
  */
 
 var express = require('express'),
-      https = require('https'),
-       http = require('http'),
-    mod_url = require('url');
+  https = require('https'),
+  http = require('http'),
+  mod_url = require('url')
 
-var utils = require('./utils');
+var utils = require('./utils')
 
 module.exports = function(options, cb) {
-  var app = express();
-  
+  var app = express()
+
   // parse credentials from Authorization header into req.remote_*
   app.use(function(req, res, next) {
-    var creds = utils.authorization(req.headers['authorization']);
-    
-    if(!creds)
-      return utils.unauthorized(res, options.realm);
-    
-    req.remote_user = creds[0];
-    req.remote_pass = creds[1];
-    
-    next();
-  });
-  
+    var creds = utils.authorization(req.headers['authorization'])
+
+    if (!creds) return utils.unauthorized(res, options.realm)
+
+    req.remote_user = creds[0]
+    req.remote_pass = creds[1]
+
+    next()
+  })
+
   // CouchDB replication base endpoint
   app.all('/:db/*', function(req, res) {
-    req.pause();
-    
+    req.pause()
+
     cb(req.params.db, req.remote_user, req.remote_pass, function(err, url) {
-      if(err)
-        return utils.unauthorized(res, options.realm, err.message);
-      
-      var remoteHeaders = {};
-      for(var header in req.headers) {
-        if(req.headers.hasOwnProperty(header)) {
-          remoteHeaders[header] = req.headers[header];
+      if (err) return utils.unauthorized(res, options.realm, err.message)
+
+      var remoteHeaders = {}
+      for (var header in req.headers) {
+        if (req.headers.hasOwnProperty(header)) {
+          remoteHeaders[header] = req.headers[header]
         }
       }
-      
-      delete remoteHeaders['authorization'];
-      delete remoteHeaders['host'];
-      
-      var remoteURL = mod_url.parse(url);
-      remoteURL.path += req.url.slice(req.params.db.length + 1);
-      
-      var request = 'https:' == remoteURL.protocol ? https.request : http.request;
-      
-      var remoteReq = request({
-        method: req.method,
-        hostname: remoteURL.hostname,
-        port: remoteURL.port || ('https:' == remoteURL.protocol ? 443 : 80),
-        path: remoteURL.path,
-        headers: remoteHeaders,
-        auth: remoteURL.auth,
-      }, function(remoteRes) {
-        // node's HTTP parser has already parsed any chunked encoding
-        delete remoteRes.headers['transfer-encoding'];
-        
-        // CouchDB replication fails unless we use a properly-cased header
-        remoteRes.headers['Content-Type'] = remoteRes.headers['content-type'];
-        delete remoteRes.headers['content-type'];
-        
-        res.writeHead(remoteRes.statusCode, remoteRes.headers);
-        remoteRes.pipe(res);
-      });
-      
+
+      delete remoteHeaders['authorization']
+      delete remoteHeaders['host']
+
+      var remoteURL = mod_url.parse(url)
+      remoteURL.path += req.url.slice(req.params.db.length + 1)
+
+      var request = 'https:' == remoteURL.protocol
+        ? https.request
+        : http.request
+
+      var remoteReq = request(
+        {
+          method: req.method,
+          hostname: remoteURL.hostname,
+          port: remoteURL.port || ('https:' == remoteURL.protocol ? 443 : 80),
+          path: remoteURL.path,
+          headers: remoteHeaders,
+          auth: remoteURL.auth
+        },
+        function(remoteRes) {
+          // node's HTTP parser has already parsed any chunked encoding
+          delete remoteRes.headers['transfer-encoding']
+
+          remoteRes.headers['content-type']
+            ? null
+            : (remoteRes.headers['content-type'] = 'application/json')
+          // CouchDB replication fails unless we use a properly-cased header
+          remoteRes.headers['Content-Type'] = remoteRes.headers['content-type']
+          delete remoteRes.headers['content-type']
+
+          res.writeHead(remoteRes.statusCode, remoteRes.headers)
+          remoteRes.pipe(res)
+        }
+      )
+
       remoteReq.on('error', function(err) {
-        res.json(503, {error: 'db_unavailable', reason: err.syscall + ' ' + err.errno});
-      });
-      
-      req.setEncoding('utf8');
-      req.resume();
-      req.pipe(remoteReq);
-    });
-  });
-  
-  return app;
-};
+        res.json(503, {
+          error: 'db_unavailable',
+          reason: err.syscall + ' ' + err.errno
+        })
+      })
+
+      req.setEncoding('utf8')
+      req.resume()
+      req.pipe(remoteReq)
+    })
+  })
+
+  return app
+}


### PR DESCRIPTION
Sometimes my reverse proxy would error and stop due to missing content-type value.  

- Added 1 line of code to check for missing `content-type` value.  If missing, set to `application/json`. 

```
    remoteRes.headers['content-type']
            ? null
            : (remoteRes.headers['content-type'] = 'application/json')
```